### PR TITLE
Allow recursive types, BooleanLiteralTypeAnnotations and do not crash on function types

### DIFF
--- a/declarations/babel.js
+++ b/declarations/babel.js
@@ -550,6 +550,7 @@ declare module '@babel/types' {
 
     declare class BooleanLiteralTypeAnnotation extends Node {
         type: 'BooleanLiteralTypeAnnotation';
+        value: boolean;
     }
 
     declare class NullLiteralTypeAnnotation extends Node {

--- a/src/collector/declarations.js
+++ b/src/collector/declarations.js
@@ -166,8 +166,8 @@ function extractCommonjsNamedExternals<+T: Node>(nodes: T[], path: string): Exte
 
 function processExportNamedDeclaration(ctx: Context, node: ExportNamedDeclaration) {
     if (isDeclaration(node.declaration)) {
+        node.declaration.leadingComments = node.leadingComments;
         const reference = processDeclaration(ctx, node.declaration);
-
         ctx.provide(reference, reference);
     }
 

--- a/src/collector/definitions.js
+++ b/src/collector/definitions.js
@@ -31,6 +31,10 @@ import {invariant} from '../utils';
 
 function processTypeAlias(ctx: Context, node: TypeAlias | DeclareTypeAlias) {
     const {name} = node.id;
+
+    // Forward declaration for the recursive types
+    ctx.define(name, t.createAny());
+
     const type = makeType(ctx, node.right);
 
     // TODO: support function aliases.

--- a/src/collector/definitions.js
+++ b/src/collector/definitions.js
@@ -108,6 +108,8 @@ function makeType(ctx: Context, node: FlowTypeAnnotation): ?Type {
             return t.createLiteral(null);
         case 'BooleanTypeAnnotation':
             return t.createBoolean();
+        case 'BooleanLiteralTypeAnnotation':
+            return t.createLiteral(node.value);
         case 'NumberTypeAnnotation':
             return t.createNumber('f64');
         case 'StringTypeAnnotation':

--- a/src/collector/definitions.js
+++ b/src/collector/definitions.js
@@ -141,7 +141,7 @@ function makeType(ctx: Context, node: FlowTypeAnnotation): ?Type {
         case 'MixedTypeAnnotation':
             return t.createMixed();
         case 'FunctionTypeAnnotation':
-            return null;
+            return t.createAny();
         default:
             invariant(false, `Unknown node: ${node.type}`);
     }

--- a/src/collector/definitions.js
+++ b/src/collector/definitions.js
@@ -32,15 +32,17 @@ import {invariant} from '../utils';
 function processTypeAlias(ctx: Context, node: TypeAlias | DeclareTypeAlias) {
     const {name} = node.id;
 
-    // Forward declaration for the recursive types
-    ctx.define(name, t.createAny());
+    if (name != 'integer') {
+        // Forward declaration for the recursive types
+        ctx.define(name, t.createAny());
 
-    const type = makeType(ctx, node.right);
+        const type = makeType(ctx, node.right);
 
-    // TODO: support function aliases.
-    invariant(type);
+        // TODO: support function aliases.
+        invariant(type);
 
-    ctx.define(name, type);
+        ctx.define(name, type);
+    }
 }
 
 // TODO: type params.
@@ -282,6 +284,9 @@ function makeIntersection(ctx: Context, node: IntersectionTypeAnnotation): ?Type
 
 function makeReference(ctx: Context, node: GenericTypeAnnotation): ?Type {
     const {name} = node.id;
+    if (name == 'integer') {
+        return t.createNumber('i64');
+    }
     const params = node.typeParameters
         && wu(node.typeParameters.params).map(n => makeType(ctx, n)).toArray();
 

--- a/src/collector/scope.js
+++ b/src/collector/scope.js
@@ -84,7 +84,7 @@ export default class Scope {
 
         if (declared) {
             invariant(decl);
-            invariant(decl.kind === 'declaration');
+            invariant(decl.kind === 'declaration' || decl.kind === 'definition');
         } else {
             invariant(!decl);
         }

--- a/src/generators/jsonSchema.js
+++ b/src/generators/jsonSchema.js
@@ -103,13 +103,13 @@ function convertType(fund: Fund, type: ?Type): Schema {
             };
         case 'union':
             const enumerate = wu(type.variants)
-                .filter(variant => variant.kind === 'literal')
+                .filter(variant => variant.kind === 'literal' && variant.value !== null)
                 .map(literal => (literal: $FlowFixMe).value)
                 .tap(value => invariant(value !== undefined))
                 .toArray();
 
             const schemas = wu(type.variants)
-                .filter(variant => variant.kind !== 'literal')
+                .filter(variant => variant.kind !== 'literal' || variant.value === null)
                 .map(variant => convert(fund, variant))
                 .toArray();
 

--- a/src/generators/jsonSchema.js
+++ b/src/generators/jsonSchema.js
@@ -12,6 +12,7 @@ export type Schema = boolean | {
     id?: string,
     $ref?: string,
     $schema?: string,
+    $comment?: string,
     title?: string,
     description?: string,
     default?: mixed,
@@ -45,6 +46,18 @@ export type Schema = boolean | {
 };
 
 function convert(fund: Fund, type: ?Type): Schema {
+    let schema = convertType(fund, type);
+    if (type && type.comment) {
+        if (schema === true) {
+            schema = { $comment: type.comment };
+        } else {
+            schema.$comment = type.comment;
+        }
+    }
+    return schema;
+}
+
+function convertType(fund: Fund, type: ?Type): Schema {
     if (!type) {
         return {
             type: 'null',

--- a/src/types.js
+++ b/src/types.js
@@ -21,6 +21,7 @@ export type TypeId = string[];
 
 export type BaseType = {
     id?: TypeId,
+    comment?: string,
 };
 
 export type RecordType = BaseType & {


### PR DESCRIPTION
Hi!
Awesome module, thanks!
The only problems I've encountered are:
- lack of BooleanLiteralTypeAnnotation support
- lack of support for recursive types
- crash (assert with null) on function types

I attempted to fix these problems, please see the PR.
It probably doesn't fix the recursive type problem for parametrized types, but at least it does so for simple ones.